### PR TITLE
added override settings functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ xrenner.py [options] INFILE (> OUTFILE)
 options:
   * -o, --output	Output format, default: sgml; alternatives: html, paula, webanno, conll
   * -m, --model	Input model directory name, in models/
+  * -x, --override Override settings in the specified sections of config.ini by reading from override.ini, default=None; possible values such as 'OntoNotes', 'GUM' 
   * --version	Print xrenner version and quit
 
 Examples:
 ========
-  * Python xrenner.py example_in.conll10 > example_out.sgml
-  * Python xrenner.py -o conll example_in.conll10 > example_out.conll
-  * Python xrenner.py -m eng -o conll example_in.conll10 > example_out.conll
+  * python xrenner.py example_in.conll10 > example_out.sgml
+  * python xrenner.py -x GUM example_in.conll10 > example_out.sgml
+  * python xrenner.py -o conll example_in.conll10 > example_out.conll
+  * python xrenner.py -m eng -o conll example_in.conll10 > example_out.conll

--- a/models/eng/override.ini
+++ b/models/eng/override.ini
@@ -1,0 +1,12 @@
+[OntoNotes]
+
+non_link_func=/cc|nsubj|cop|aux|dep|punct|conj|appos|mark|xcomp|advcl|tmod|discourse|advmod|parataxis|neg/
+
+remove_singletons=True
+
+
+[GUM]
+
+non_link_func=/cc|rcmod|nsubj|cop|aux|dep|punct|conj|appos|mark|xcomp|vmod|advcl|tmod|discourse|advmod|parataxis|neg/
+
+remove_singletons=False

--- a/xrenner.py
+++ b/xrenner.py
@@ -331,6 +331,7 @@ def process_sentence(conll_tokens, tokoffset, sentence):
 parser = argparse.ArgumentParser()
 parser.add_argument('-o', '--output', action="store", dest="format", default="sgml", help="Output format, default: sgml; alternatives: html, paula, webanno, conll")
 parser.add_argument('-m', '--model', action="store", dest="model", default="eng", help="Input model directory name, in models/")
+parser.add_argument('-x', '--override', action="store", dest="override", default=None, help="provide an override file to run alternative settings for config.ini")
 parser.add_argument('file', action="store", help="Input file name to process")
 parser.add_argument('--version', action='version', version=xrenner_version)
 
@@ -340,7 +341,8 @@ options = parser.parse_args()
 
 out_format = options.format
 model = options.model
-lex = LexData(model)
+override = options.override
+lex = LexData(model,override)
 infile = open(options.file)
 
 conll_tokens = []


### PR DESCRIPTION
When running xrenner, if command line argument -x or --override is specified, such as "-x GUM", then the script will read from the override.ini file and look for the specified section ([GUM] in this case). The settings from that section will override the corresponding settings in the config.ini file. 
